### PR TITLE
Fix google login notifications

### DIFF
--- a/backend/ServiPuntos.API/Controllers/NotificacionController.cs
+++ b/backend/ServiPuntos.API/Controllers/NotificacionController.cs
@@ -23,8 +23,16 @@ namespace ServiPuntos.API.Controllers
 
         private Guid GetUserId()
         {
-            var claim = User.FindFirst(ClaimTypes.NameIdentifier) ?? User.FindFirst("sub");
-            return claim != null && Guid.TryParse(claim.Value, out var id) ? id : Guid.Empty;
+            // Buscar el identificador de usuario en diferentes claims para
+            // asegurar compatibilidad con distintos flujos de autenticación
+            var claim =
+                User.FindFirst(ClaimTypes.NameIdentifier) ??
+                User.FindFirst("nameid") ?? // Por si la librería no mapea el claim
+                User.FindFirst("sub");
+
+            return claim != null && Guid.TryParse(claim.Value, out var id)
+                ? id
+                : Guid.Empty;
         }
 
         [HttpGet("mine")]

--- a/frontend-web/src/components/auth/AuthCallback.js
+++ b/frontend-web/src/components/auth/AuthCallback.js
@@ -30,9 +30,8 @@ const AuthCallback = () => {
           return;
         }
 
-        // Guardar el token en localStorage y programar cierre automático
-        localStorage.setItem("token", token);
-        authService.scheduleAutoLogout();
+        // Guardar el token y configurar cierre automático
+        authService.loginWithToken(token);
 
         // Verificar que el token sea válido
         if (!authService.isAuthenticated()) {

--- a/frontend-web/src/services/authService.js
+++ b/frontend-web/src/services/authService.js
@@ -137,6 +137,14 @@ register: async (name, email, password, ci, tenantId) => {
     }
   },
 
+  // Guardar un token ya obtenido (por ejemplo, tras login con Google)
+  loginWithToken: (token) => {
+    if (token) {
+      localStorage.setItem('token', token);
+      scheduleAutoLogout();
+    }
+  },
+
   verifyPassword: async (email, password) => {
     try {
       await axios.post(`${API_URL}verify-password`, { email, password });


### PR DESCRIPTION
## Summary
- add a utility to store tokens from Google login
- use that utility in the auth callback so tokens persist
- relax user id parsing in notifications controller so Google tokens work

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685068213ac0832f84078127943f0dd9